### PR TITLE
Fix parenthesis mismatch.

### DIFF
--- a/modules/module-asm.el
+++ b/modules/module-asm.el
@@ -14,7 +14,7 @@
     (set-syntax-table (make-syntax-table asm-mode-syntax-table))
     (modify-syntax-entry asm-comment-char "< b")
     ;; Fix one level comments.
-    (set (make-local-variable #'comment-start) (string asm-comment-char)))
+    (set (make-local-variable #'comment-start) (string asm-comment-char))))
 
 (provide 'module-asm)
 ;;; module-asm.el ends here


### PR DESCRIPTION
Small but in master version: the file module-asm.el is missing a closing parenthesis.