### PR TITLE
Fix bindings being shadowed by the doom popup

### DIFF
--- a/core/defuns/defuns-popups.el
+++ b/core/defuns/defuns-popups.el
@@ -19,14 +19,6 @@
     map)
    "Active keymap in popup windows.")
 
-(defvar doom-popup-mode-local-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map [remap evil-force-normal-state] 'doom/popup-close)
-    (define-key map [escape] 'doom/popup-close)
-    (define-key map (kbd "ESC") 'doom/popup-close)
-    map)
-  "Active keymap in popup windows with ESC bindings.")
-
 (advice-add 'doom/evil-window-move :around 'doom*popup-window-move)
 
 ;;;###autoload
@@ -156,9 +148,10 @@ variables."
                       doom-popup-rules)))
     (setq doom-last-popup (current-buffer))
     (setq-local doom-popup-rule rules)
-    (let ((map doom-popup-mode-map))
-      (unless (memq :noesc rules)
-        (use-local-map doom-popup-mode-local-map)))))
+    (unless (memq :noesc rules)
+      (define-key map [remap evil-force-normal-state] 'doom/popup-close)
+      (define-key map [escape] 'doom/popup-close)
+      (define-key map (kbd "ESC") 'doom/popup-close))))
 
 (provide 'defuns-popups)
 ;;; defuns-popups.el ends here


### PR DESCRIPTION
Bindings defined in a major mode do not work in popups. These changes fix this.
Instead of using 'use-local-map' (which overrides the keybindings of the major mode), add new keybindings to the doom-popup-mode-map keymap.

I am not totally aware of why you were using 'use-local-map'. This fix removes the idea of replacing the local map.