### PR TITLE
Fix wrong smart forward and backward bindings

### DIFF
--- a/core/core-editor.el
+++ b/core/core-editor.el
@@ -253,7 +253,7 @@
   :config (push '("true" "false") rotate-text-words))
 
 (use-package smart-forward
-  :commands (smart-up smart-down smart-left smart-right))
+  :commands (smart-up smart-down smart-backward smart-forward))
 
 (use-package smartparens
   :config

--- a/private/my-bindings.el
+++ b/private/my-bindings.el
@@ -206,8 +206,8 @@
       :n  "gr" 'doom:eval-region
       :n  "gR" 'doom:eval-buffer
       :v  "gR" 'doom:eval-region-and-replace
-      :m  "g]" 'smart-right
-      :m  "g[" 'smart-left
+      :m  "g]" 'smart-forward
+      :m  "g[" 'smart-backward
       :v  "@"  'doom/evil-macro-on-all-lines
       :n  "g@" 'doom/evil-macro-on-all-lines
       ;; Repeat in visual mode


### PR DESCRIPTION
The smart-forward package does not provide the functions smart-left or smart-right. Instead, the functions should be named smart-forward and smart-backward.