### PR TITLE
Enable company mode when asked to autocomplete

### DIFF
--- a/core/defuns/defuns-company.el
+++ b/core/defuns/defuns-company.el
@@ -42,6 +42,8 @@
   "`company-mode' completion backend that completes whole-lines, akin to vim's
 C-x C-l."
   (interactive (list 'interactive))
+  (require 'company)
+  (unless (bound-and-true-p company-mode) (company-mode))
   (let ((lines (doom--company-whole-lines)))
     (cl-case command
       (interactive (company-begin-backend 'doom/company-whole-lines))
@@ -59,8 +61,8 @@ C-x C-l."
   "Bring up the completion popup. If only one result, complete it."
   (interactive)
   (require 'company)
-  (when (and (bound-and-true-p company-mode)
-             (company-manual-begin)
+  (unless (bound-and-true-p company-mode) (company-mode))
+  (when (and (company-manual-begin)
              (= company-candidates-length 1))
     (company-complete-common)))
 


### PR DESCRIPTION
I'm trying to fix two things with this PL:

1) I noticed that when using C-x C-l in insert mode, the line-autocomplete would not work because company was not enabled. I now load company mode when using that command.

2) If using the command C-SPC to autocomplete, if company mode is not enabled, enable it.

Feel free to add both hunks, only the first one, or none ;)