### PR TITLE
doom-make-xpm: no need to reverse the data

### DIFF
--- a/core/core-modeline.el
+++ b/core/core-modeline.el
@@ -133,7 +133,7 @@ cached the first time."
      (let ((data nil)
            (i 0))
        (setq data (make-list height (make-list width 1)))
-       (pl/make-xpm "percent" color color (reverse data))))))
+       (pl/make-xpm "percent" color color data)))))
 
 (defun doom-buffer-path ()
   "Displays the buffer's full path relative to the project root (includes the


### PR DESCRIPTION
The data is same front to back, since it's a list of identical lists of identical elements, so there's no need to reverse it before passing it to pl/make-xpm.

@hlissner Let me know if I'm wrong about this, or if there's a conceptual reason to keep the `reverse`, but I don't think you need it.