### PR TITLE
Quickfixes

### DIFF
--- a/core/core-ui.el
+++ b/core/core-ui.el
@@ -10,7 +10,7 @@
  ;; remove continuation arrow on right fringe
  fringe-indicator-alist (delq (assq 'continuation fringe-indicator-alist)
                               fringe-indicator-alist)
- highlight-nonselected-window nil
+ highlight-nonselected-windows nil
  image-animate-loop t
  indicate-buffer-boundaries nil
  indicate-empty-lines nil

--- a/modules/feature/syntax-checker/config.el
+++ b/modules/feature/syntax-checker/config.el
@@ -27,7 +27,7 @@
   (advice-add 'evil-force-normal-state :after '+syntax-checkers|flycheck-buffer))
 
 
-(def-package! flycheck-pos-type :after flycheck
+(def-package! flycheck-pos-tip :after flycheck
   :config
   (setq flycheck-pos-tip-timeout 10
         flycheck-display-errors-delay 0.5)


### PR DESCRIPTION
While looting your configuration for awesomeness i found some typos. Also i hope you will add your awesome mode-line to the doom-one theme repository soon :) as i will never be able to use evil even thou i use vim regularly, i had to edit some segments for it to work properly without evil and now my init.el is frickin huge. Not sure if it will help you but here are the segments i had to change:


```elisp
(defsubst +doom-modeline--anzu ()
  "Show number of :s matches in real time."
  (when anzu--state
    (propertize
     (let* ((here anzu--current-position)
            (total anzu--total-matched)
            (status (cl-case anzu--state
                      (search (format " %s/%d%s "
                                      (anzu--format-here-position here total)
                                      total (if anzu--overflow-p "+" "")))
                      (replace-query (format " %d replace " total))
                      (replace (format " %d/%d " here total)))))
       status)
     'face (if (active) 'doom-modeline-panel))))

(defun +doom-modeline--macro-recording ()
  "Display current macro being recorded."
  (when (and (active) (or defining-kbd-macro executing-kbd-macro))
    (let ((sep (propertize " " 'face 'doom-modeline-panel)))
      (concat sep
              (propertize "Macro"
                          'face 'doom-modeline-panel)
              sep
              (all-the-icons-octicon "triangle-right"
                                     :face 'doom-modeline-panel
                                     :v-adjust -0.05)
              sep))))

(def-modeline-segment! selection-info
  "Information about the current selection, such as how many characters and
lines are selected, or the NxM dimensions of a block selection."
  (when mark-active
    (concat
     " "
     (propertize
      (let ((reg-beg (region-beginning))
            (reg-end (region-end)))
        (let ((lines (count-lines reg-beg (min (1+ reg-end) (point-max))))
              (chars (- (1+ reg-end) reg-beg))
              (cols (1+ (abs (- (doom-column reg-end)
                                (doom-column reg-beg))))))
          (cond
           ;; rectangle selection
           ((bound-and-true-p rectangle-mark-mode)
            (format " %dx%dB " lines (1- cols)))
           ((> lines 1)
            (format " %dC %dL " chars lines))
           (t (format " %dC " (1- chars)))
           )))
      'face 'doom-modeline-highlight))))
```