### PR TITLE
add git-timemachine

### DIFF
--- a/modules/feature/version-control/+git.el
+++ b/modules/feature/version-control/+git.el
@@ -31,6 +31,18 @@
 (def-package! browse-at-remote
   :commands (browse-at-remote browse-at-remote-get-url))
 
+(def-package! git-timemachine
+  :commands (git-timemachine git-timemachine-toggle)
+  :config
+  (add-hook! 'git-timemachine-mode-hook #'evil-force-normal-state)
+  (map! :map git-timemachine-mode-map
+        :nv "p" 'git-timemachine-show-previous-revision
+        :nv "n" 'git-timemachine-show-next-revision
+        :nv "g" 'git-timemachine-show-nth-revision
+        :nv "q" 'git-timemachine-quit
+        :nv "w" 'git-timemachine-kill-abbreviated-revision
+        :nv "W" 'git-timemachine-kill-revision
+        :nv "b" 'git-timemachine-blame))
 
 (def-package! magit
   :commands magit-status

--- a/modules/feature/version-control/packages.el
+++ b/modules/feature/version-control/packages.el
@@ -7,6 +7,7 @@
 ;;; +git
 (package! browse-at-remote)
 (package! git-gutter-fringe)
+(package! git-timemachine)
 (package! gitconfig-mode)
 (package! gitignore-mode)
 (package! magit)


### PR DESCRIPTION
I've been migrating to a new emacs config based on yours after coming from Spacemacs and am still very much a novice at emacs configuration and elisp, so please let me know if you see anything that needs to be changed.

I ran into two small challenges integrating ```git-timemachine```:

+ The default mode keybindings were not being applied, so I added them manually in the ```def-package!``` definition.

+ On entering the ```git-timemachine``` minor mode, none of the mode specific keybindings would work (they were still bound to their evil equivalents), until I hit escape (```evil-force-normal-state```), after which all of the ```git-timemachine``` specific keybindings functioned properly. To work around this I added a hook to execute ```evil-force-normal-state``` on entering the minor mode.

Thanks for making your configuration public, it's extremely well thought out and has proved to be a fantastic base to create my configuration from.