### PR TITLE
add `doom/large-file-check to prompt literal open of large files

### DIFF
--- a/core/autoload/editor.el
+++ b/core/autoload/editor.el
@@ -206,3 +206,17 @@ for function signatures or notes. Run again to clear the header line."
                     (setq content (replace-regexp-in-string "\n" " " content t t))
                     (setq content (replace-regexp-in-string "\\s-+" " " content))
                     content)))))
+
+;;;###autoload
+(defun doom/check-large-file ()
+  (let* ((filename (buffer-file-name))
+         (size (nth 7 (file-attributes filename))))
+    (when (and
+           (not (memq major-mode doom-large-file-modes-list))
+           size (> size (* 1024 1024 doom-large-file-size))
+           (y-or-n-p (format (concat "%s is a large file, open literally to "
+                                     "avoid performance issues?")
+                             filename)))
+      (setq buffer-read-only t)
+      (buffer-disable-undo)
+      (fundamental-mode))))

--- a/core/core-editor.el
+++ b/core/core-editor.el
@@ -1,5 +1,16 @@
 ;;; core-editor.el --- filling the editor shaped hole in the Emacs OS
 
+
+(defvar doom-large-file-size 1
+  "Size (in MB) above which the user will be propmpted to open the file literally to avoid
+  performance issues. Opening literally means that no major or minor modes are active and
+  the buffer is readonly.")
+
+(defvar doom-large-file-modes-list 
+  '(archive-mode tar-mode jka-compr git-commit-mode image-mode
+    doc-view-mode doc-view-mode-maybe ebrowse-tree-mode pdf-view-mode)
+  "Major modes which `doom/check-large-file' will not be automatically applied to")
+
 (setq-default
  ;; Save clipboard contents into kill-ring before replacing them
  save-interprogram-paste-before-kill t
@@ -87,6 +98,9 @@
                (string-match-p "^[\s\t]*$" linestr))
       (insert linestr))))
 (advice-add #'delete-trailing-whitespace :around #'doom*delete-trailing-whitespace)
+
+;; automatically check for large files and optionally prompt to open literally
+(add-hook 'find-file-hook 'doom/check-large-file)
 
 
 ;;


### PR DESCRIPTION
Add a prompt that will ask to open large files literally to avoid performance issues. A large file is determined by the checking the file size against the variable ```doom-large-file-size``` (default: 1MB). Opening a file literally essentially means that:

* Major and minor modes are disabled
* Buffer is readonly
* Undo is disabled

This results in drastic performance increases when opening a large file with the intention simply viewing it. This does not interfere with the built in emacs prompt when opening very large files.

Also, let me know if this functionality should be located somewhere else. ```core/editor``` seemed like the most logical location for it.