### PR TITLE
add simple h/j/k/l keybindings to navigate neotree

### DIFF
--- a/modules/feature/evil/autoload/neotree.el
+++ b/modules/feature/evil/autoload/neotree.el
@@ -17,3 +17,41 @@
           (neotree-dir project-root))
         (neotree-find path project-root)))))
 
+;;;###autoload
+(defun +evil/neotree-collapse-or-up ()
+  "Collapse an expanded directory node or go to the parent node."
+  (interactive)
+  (let ((node (neo-buffer--get-filename-current-line)))
+    (when node
+      (if (file-directory-p node)
+          (if (neo-buffer--expanded-node-p node)
+              (+evil/neotree-collapse)
+            (neotree-select-up-node))
+        (neotree-select-up-node)))))
+
+;;;###autoload
+(defun +evil/neotree-collapse ()
+  "Collapse a neotree node."
+  (interactive)
+  (let ((node (neo-buffer--get-filename-current-line)))
+    (when node
+      (when (file-directory-p node)
+        (neo-buffer--set-expand node nil)
+        (neo-buffer--refresh t))
+      (when neo-auto-indent-point
+        (neo-point-auto-indent)))))
+
+;;;###autoload
+(defun +evil/neotree-expand-or-open ()
+  "Expand or open a neotree node."
+  (interactive)
+  (let ((node (neo-buffer--get-filename-current-line)))
+    (when node
+      (if (file-directory-p node)
+          (progn
+            (neo-buffer--set-expand node t)
+            (neo-buffer--refresh t)
+            (when neo-auto-indent-point
+              (next-line)
+              (neo-point-auto-indent)))
+        (call-interactively 'neotree-enter)))))

--- a/modules/feature/evil/config.el
+++ b/modules/feature/evil/config.el
@@ -403,6 +403,10 @@ algorithm is just confusing, like in python or ruby."
           :Lm "K"        'neotree-select-previous-sibling-node
           :Lm "H"        'neotree-select-up-node
           :Lm "L"        'neotree-select-down-node
+          :Lm "h"        '+evil/neotree-collapse-or-up
+          :Lm "j"        'neotree-next-line
+          :Lm "k"        'neotree-previous-line
+          :Lm "l"        '+evil/neotree-expand-or-open
           :Lm "v"        'neotree-enter-vertical-split
           :Lm "s"        'neotree-enter-horizontal-split
           :Lm "c"        'neotree-create-node


### PR DESCRIPTION
Add additional h/j/k/l keybindings to neotree.
* ```h``` - if current node is expanded collapse it, otherwise move up to parent node
* ```j``` - select next node
* ```k``` - select previous node
* ```l``` - expand node (if folder) or open (if file)