### PR TITLE
added evil-mc

### DIFF
--- a/modules/feature/evil/config.el
+++ b/modules/feature/evil/config.el
@@ -284,6 +284,8 @@
 algorithm is just confusing, like in python or ruby."
     (setq-local evilmi-always-simple-jump t)))
 
+(def-package! evil-mc :demand t
+  :config (global-evil-mc-mode 1))
 
 (def-package! evil-multiedit
   :commands (evil-multiedit-match-all
@@ -410,4 +412,3 @@ algorithm is just confusing, like in python or ruby."
           :Lm "\C-r"     'neotree-refresh
           :Lm "r"        'neotree-rename-node
           :Lm "R"        'neotree-change-root)))
-

--- a/modules/feature/evil/packages.el
+++ b/modules/feature/evil/packages.el
@@ -11,6 +11,7 @@
 (package! evil-indent-plus)
 (package! evil-matchit)
 (package! evil-multiedit)
+(package! evil-mc)
 (package! evil-numbers)
 (package! evil-textobj-anyblock)
 (package! evil-search-highlight-persist)


### PR DESCRIPTION
Add the evil-mc package. 

It worked perfectly for me in my config, however using your config only the current cursor would delete characters properly. After a little digging I was able to get it to work properly after commenting out the following line in your ```+bindings.el``` file:

    :i [remap delete-backward-char]   'doom/deflate-space-maybe
 
Overriding ```delete-backward-char``` was conflicting with the delete functionality for the other cursors. I haven't looked into it, but you can probably get it to work with your custom delete function without too much trouble.

Quick Highlights:

```ctrl-n``` - place cursor next matching word
```ctrl-p``` - place cursor at previous matching word
```gru``` - clear cursors
```grj``` - make cursor and move down
```grk``` - make cursor and move up
```grs``` - pause cursors (allows you to move around without moving other cursors)
```grr``` - resume cursors
```grh``` - make cursor here
```grf``` - make cursor and go to first cursor
```grl``` - make cursor and go to last cursor

There are several more keybinds + functions, but those are the ones I use the most.