### PR TITLE
add `doom/deflate-space-maybe' as a custom evil-mc custom known command

### DIFF
--- a/modules/feature/evil/config.el
+++ b/modules/feature/evil/config.el
@@ -285,7 +285,10 @@ algorithm is just confusing, like in python or ruby."
     (setq-local evilmi-always-simple-jump t)))
 
 (def-package! evil-mc :demand t
-  :config (global-evil-mc-mode 1))
+  :config 
+  (global-evil-mc-mode 1)
+  (setq evil-mc-custom-known-commands
+    '((doom/deflate-space-maybe . ((:default . evil-mc-execute-default-evil-delete))))))
 
 (def-package! evil-multiedit
   :commands (evil-multiedit-match-all


### PR DESCRIPTION
This should fix the backspace issue and will properly execute ```doom/deflate-space-maybe``` across all cursors. 