### PR TITLE
disable copy on visual state change for BOTH mac and linux

### DIFF
--- a/core/core-os.el
+++ b/core/core-os.el
@@ -14,6 +14,12 @@
       select-enable-clipboard t
       select-enable-primary t)
 
+(after! evil
+  ;; stop copying each visual state move to the clipboard:
+  ;; https://bitbucket.org/lyro/evil/issue/336/osx-visual-state-copies-the-region-on
+  ;; Most of this code grokked from:
+  ;; http://stackoverflow.com/questions/15873346/elisp-rename-macro
+  (advice-add #'evil-visual-update-x-selection :override #'ignore))
 
 (cond (IS-MAC
        (setq mac-command-modifier 'meta
@@ -46,15 +52,7 @@
                         exec-path)))
              (t
               (when (require 'osx-clipboard nil t)
-                (osx-clipboard-mode +1))))
-
-       (after! evil
-         ;; On OSX, stop copying each visual state move to the clipboard:
-         ;; https://bitbucket.org/lyro/evil/issue/336/osx-visual-state-copies-the-region-on
-         ;; Most of this code grokked from:
-         ;; http://stackoverflow.com/questions/15873346/elisp-rename-macro
-         (when (or (featurep 'mac) (featurep 'ns))
-           (advice-add #'evil-visual-update-x-selection :override #'ignore))))
+                (osx-clipboard-mode +1)))))
 
       (IS-LINUX
        ;; nothing yet


### PR DESCRIPTION
Disable automatic copying to clipboard anytime visual state changes. This was previously only applied when running on macOS, but has now been modified to apply to linux as well.