### PR TITLE
only disable show-paren-mode locally for org mode buffers

### DIFF
--- a/modules/lang/org/config.el
+++ b/modules/lang/org/config.el
@@ -47,7 +47,8 @@
   (setq line-spacing 1)
 
   ;; show-paren-mode causes problems for org-indent-mode
-  (show-paren-mode -1)
+  (make-local-variable 'show-paren-mode)
+  (setq show-paren-mode nil)
 
   (visual-line-mode +1)
   (when (and (featurep 'evil) evil-mode)


### PR DESCRIPTION
Currently loading ```org-mode``` will disable ```show-paren-mode``` globally. Previously this wasn't noticeable because it was toggled on and off frequently via hooks, however it is not being re-activated after loading an ```org-mode``` buffer. This commit will make ```org-mode``` only disable show-paren-mode locally in the ```org-mode``` buffer.

Also, holy cow you've been slinging some elisp. All of your recent changes have been awesome!