### PR TITLE
make doom/blink-cursor interactive

### DIFF
--- a/modules/ui/doom/config.el
+++ b/modules/ui/doom/config.el
@@ -93,6 +93,7 @@
         (doom/blink-cursor))))
 
   (defun doom/blink-cursor (&rest _)
+    (interactive)
     (unless (minibufferp)
       (nav-flash-show)
       ;; only show in the current window


### PR DESCRIPTION
Make ```doom/blink-cursor``` an interactive function, so that it can easily be called on demand to flash the cursor line.