### PR TITLE
disable ivy magic slash non-match action

### DIFF
--- a/modules/completion/ivy/config.el
+++ b/modules/completion/ivy/config.el
@@ -31,7 +31,9 @@ session)."
         ;; Don't use ^ as initial input
         ivy-initial-inputs-alist nil
         ;; highlight til EOL
-        ivy-format-function #'ivy-format-function-line)
+        ivy-format-function #'ivy-format-function-line
+        ;; disable magic slash on non-match
+        ivy-magic-slash-non-match-action nil)
 
   (after! magit      (setq magit-completing-read-function #'ivy-completing-read))
   (after! yasnippet  (push #'+ivy-yas-prompt yas-prompt-functions))


### PR DESCRIPTION
I recently added the ability to customize the behavior of the 'magic slash' in ivy when adding a slash to a non-match when working with files. Specifically the variable ```ivy-magic-slash-non-match-action```, which has three possible values:

* ```’ivy-magic-slash-non-match-cd-selected``` - automatically 'cd' into closest matching directory (default)
* ```’ivy-magic-slash-non-match-create``` - automatically create a new folder based on the currently entered text and cd into it
* ```nil``` - do nothing and add the slash literally

The reason I added this variable to ivy was because the default behavior made it impossible to create files inside of folders that don't exist, but whose name would also match an existing folder. For example, trying to add the file: ```~/doc/todo.org``` is impossible in ```counsel-find-file``` when the folder ```~/doc``` does not already exist and the folder ```~/Documents``` does exist. Using the default behavior, ivy will always 'cd' into the ```~/Documents``` folder instead of allowing you to define the full path ```~/doc/todo.org```.

I think disabling the behavior in this scenario is the best option, since automatically creating a folder anytime a slash is added to a non existing folder name seems to be a bit too much for such a simple operation to do. So, I chose to set this value to ```nil``` in this PR. 

It's a very small issue, but something that previously bit me rather frequently and forced me into the terminal to manually create a folder.

Thanks!