### PR TITLE
lang/purescript: small improvements

### DIFF
--- a/modules/lang/purescript/config.el
+++ b/modules/lang/purescript/config.el
@@ -2,14 +2,13 @@
 
 (def-package! purescript-mode
   :mode "\\.purs$"
-  :init
-  (add-hook 'purescript-mode-hook #'flycheck-mode)
-  (add-hook 'purescript-mode-hook #'rainbow-delimiters-mode)
   :config
+  (add-hook! 'purescript-mode-hook #'flycheck-mode)
+  (add-hook! 'purescript-mode-hook #'company-mode)
+  (add-hook! 'purescript-mode-hook #'purescript-indentation-mode)
+  (add-hook! 'purescript-mode-hook #'rainbow-delimiters-mode)
   (load "purescript-mode-autoloads" nil t)
 )
-
-;; Seems broken at the moment
 
 ;; (def-package! flycheck-purescript
 ;;   :after purescript-mode
@@ -21,12 +20,6 @@
   :after purescript-mode
   :config
   (require 'psc-ide)
-  (add-hook! 'purescript-mode-hook
-    (lambda ()
-      (company-mode)
-      (psc-ide-mode)
-      (turn-on-purescript-indentation)
-    )
-  )
+  (add-hook! 'purescript-mode-hook #'psc-ide-mode)
 )
 

--- a/modules/lang/purescript/packages.el
+++ b/modules/lang/purescript/packages.el
@@ -1,7 +1,12 @@
 ;; -*- no-byte-compile: t; -*-
 ;;; lang/purescript/packages.el
 
+;; As far as I can tell, at the moment, flycheck-purescript does not work well
+;; due to expecting the compiler to be psc rather than purs.
+;; However, one of purescript-mode or psc-ide seems to handle flycheck, so it
+;; might be unnecessary altogether.
 ;; (package! flycheck-purescript)
+
 (package! psc-ide)
 (package! purescript-mode)
 


### PR DESCRIPTION
I think I was doing some `:config` stuff in `:init`. Tiny improvements and documented why `flycheck-purescript` is commented out.