### PR TITLE
Support running from non-standard HOME directory

### DIFF
--- a/core/core.el
+++ b/core/core.el
@@ -22,7 +22,7 @@
   "If non-nil, all doom functions will be verbose. Set DEBUG=1 in the command
 line or use --debug-init to enable this.")
 
-(defvar doom-emacs-dir user-emacs-directory
+(defvar doom-emacs-dir (expand-file-name user-emacs-directory)
   "The path to this emacs.d directory.")
 
 (defvar doom-core-dir (concat doom-emacs-dir "core/")


### PR DESCRIPTION
I wanted to try this config without moving my current `.emacs.d` directory, so I cloned into a different directory and launched with that directory as my HOME:

    HOME=/home/tsanders/doom emacs

This caused the following error:

    File error: Cannot open load file, Not a directory, core-lib

After looking into it some more, I think the paths are (partially?) expanded as part of the `make compile` process, so my `load-path` would contain `~/doom/.emacs.d/core`, which expands to `/home/tsanders/doom/doom/.emacs.d/core` instead of `/home/tsanders/doom/.emacs.d/core`, etc..

Compiling with the alternate HOME seems to fix the issue:

    HOME=/home/tsanders/doom make compile

However, this patch is another fix I have tried that appears to work for me regardless of the compile environment: If we expand HOME the first time the base path is set, all downstream references should use the correct path.

(I'm not super familiar with this project, the elisp byte compile process, or the implications that this change might have, so please test and make sure this doesn't break anything.  :) )