### PR TITLE
lang/go: add missing command-go-gocode-command variable

### DIFF
--- a/modules/lang/go/config.el
+++ b/modules/lang/go/config.el
@@ -69,6 +69,7 @@
 
 
 (def-package! company-go
+  :init (setq command-go-gocode-command "gocode")
   :when (featurep! :completion company)
   :after go-mode
   :config


### PR DESCRIPTION
A fix for issue #89 