### PR TITLE
Ignore only root init.el

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .local/
 .cask/
 var/
-init.el
+/init.el
 
 # emacs tempfiles that shouldn't be there
 .mc-lists.el


### PR DESCRIPTION
Hey, until now I had my private module in a separate repo and sym linking it inside your repo but today I decided to fork your config and place my private module there. What I noticed is that init.el file in my private module was ignored and I saw that you had ignored all init.el files in the repo which I think is a mistake. I've updated the .gitignore to ignore only the root init.el.