### PR TITLE
app/irc: def-setting don't eval letvars

### DIFF
--- a/modules/app/irc/config.el
+++ b/modules/app/irc/config.el
@@ -25,7 +25,7 @@ playback.")
 
 (def-setting! :irc (server letvars)
   "Registers an irc server for circe."
-  `(cl-pushnew (cons ,server ,letvars) +irc-connections
+  `(cl-pushnew ',(cons server letvars) +irc-connections
                :test #'equal :key #'car))
 
 (defvar +irc--defer-timer nil)


### PR DESCRIPTION
if not done this way it will try to call letvars and :user doesn't exists