### PR TITLE
Fix company backends setting

### DIFF
--- a/modules/completion/company/config.el
+++ b/modules/completion/company/config.el
@@ -9,7 +9,8 @@
                   collect `(defun ,def-name ()
                              (when (eq major-mode ',mode)
                                (require 'company)
-                               (cl-pushnew ',backends company-backends :test #'equal)))
+                               ,@(cl-loop for backend in backends
+                                          collect `(cl-pushnew ',backend company-backends :test #'equal))))
                   collect `(add-hook! ,mode #',def-name)))))
 
 

--- a/modules/lang/scala/config.el
+++ b/modules/lang/scala/config.el
@@ -5,7 +5,7 @@
   :config
   (add-hook 'scala-mode-hook #'ensime-mode)
   (setq scala-indent:align-parameters t)
-  (set! :company-backend 'scala-mode '(ensime-company company-yasnippet)))
+  (set! :company-backend 'scala-mode '(company-yasnippet)))
 
 
 (def-package! sbt-mode :after scala-mode)


### PR DESCRIPTION
After doing a bit of debugging I noticed the the ```:company-backend``` setting is not correctly adding individual backends, but is instead always appending the entire list of backends.

For example, after executing the following line:

     (set! :company-backend 'scala-mode '(ensime-company company-yasnippet)))

The ```company-backends``` var for scala mode will look like:

    '((ensime-company company-yasnippet)
       backend1 backend2 backend...)

What I would expect to happen would be that the value would look like:

    '(ensime-company company-yasnippet backend1 backend2 backend...)

I've updated the ```def-setting!``` so that it will add these values into the existing flat structure, and now has the additional benefit preventing duplicate backends from being added to the list. Additionally, I've included in this pull request the removal of the explicit add of the ```ensime-company``` backend, since it's [already added](https://github.com/ensime/ensime-emacs/blob/master/ensime-mode.el#L270) when ```ensime-mode``` is enabled.