### PR TITLE
doom-modeline: Gracefully handle nil buffer-file-name in org indirect buffers

### DIFF
--- a/modules/ui/doom-modeline/config.el
+++ b/modules/ui/doom-modeline/config.el
@@ -325,8 +325,8 @@ directory, the file name, and its state (modified, read-only or non-existent)."
 (def-modeline-segment! vcs
   "Displays the current branch, colored based on its state."
   (when vc-mode
-    (let ((backend (vc-backend buffer-file-name))
-          (state   (vc-state buffer-file-name))
+    (let ((backend (when buffer-file-name (vc-backend buffer-file-name)))
+          (state   (when buffer-file-name (vc-state buffer-file-name)))
           (face    'mode-line-inactive)
           (active  (active))
           (all-the-icons-scale-factor 1.0)


### PR DESCRIPTION
Hi there!

And thanks for a fantastic effort on this config and the doom-themes! 👏  I venture here for inspiration regularly.

This pr fixes an issue where the modeline dissappears in buffers made from `org-tree-to-indirect-buffer`, because of the `vcs` modeline needing a `buffer-file-name` that in this case is `nil`.

Sidenote;

I wanted to try making use of the doom-modeline myself in a custom config, and seeing this in the [emacs-doom-themes](https://github.com/hlissner/emacs-doom-themes) readme

> I'm working on making my modeline more accessible. In the meantime, check out my mode-line configuration in my emacs.d.

I thought I'd have a go. I don't know your status or intentions on this, and this is by no means work that's thought through, but at least here's [what's needed to make the modeline work outside of `hlissner/.emacs.d`](https://github.com/torgeir/.emacs.d/blob/1f2c1894655053a680bfd8b9441062c1c3f6b525/site-lisp/t-doom-modeline/t-doom-modeline.el#L4-L134).

Everything in between `;; TODO torgeir added this` is ported from elsewhere in your config. The one change I had to make was defining `(defun doom-project-root () (t/project-root))` to a function local to my config.

Do what you want with it, throw it away or use it to simplify extracting the parts you need to make it standalone!

