### PR TITLE
Fix: org/babel: sh -> shell

### DIFF
--- a/modules/org/org-babel/config.el
+++ b/modules/org/org-babel/config.el
@@ -27,7 +27,7 @@
              restclient ; ob-restclient
              ruby
              rust       ; ob-rust
-             sh
+             shell
              sqlite
              sql-mode   ; ob-sql-mode
              translate  ; ob-translate


### PR DESCRIPTION
sh was renamed to shell in Org 8.2 [1] and this may result in some undesired
behavior as it will fall back to the bundled ob-sh.el

[1] http://orgmode.org/cgit.cgi/org-mode.git/plain/etc/ORG-NEWS