### PR TITLE
Add: feature/syntax-checker: add flycheck-cask for emacs-lisp

### DIFF
--- a/modules/feature/syntax-checker/config.el
+++ b/modules/feature/syntax-checker/config.el
@@ -27,3 +27,8 @@
   (setq flycheck-pos-tip-timeout 10
         flycheck-display-errors-delay 0.5)
   (flycheck-pos-tip-mode +1))
+
+(when (featurep! :lang emacs-lisp)
+  (def-package! flycheck-cask
+    :commands flycheck-cask-setup
+    :init (add-hook 'flycheck-mode-hook #'flycheck-cask-setup)))

--- a/modules/feature/syntax-checker/packages.el
+++ b/modules/feature/syntax-checker/packages.el
@@ -4,3 +4,6 @@
 (package! flycheck)
 (package! flycheck-pos-tip)
 
+(when (featurep! :lang emacs-lisp)
+  (package! flycheck-cask))
+


### PR DESCRIPTION
This is used to set up the flycheck load-path correctly for emacs-lisp package
development.