### PR TITLE
Fix invalid default for ensime-eldoc-hints (now set to 'all)

### DIFF
--- a/modules/lang/scala/config.el
+++ b/modules/lang/scala/config.el
@@ -17,7 +17,7 @@
 
   (setq ensime-startup-snapshot-notification nil
         ensime-startup-notification nil
-        ensime-eldoc-hints t
+        ensime-eldoc-hints 'all
         ;; let DOOM handle company setup
         ensime-completion-style nil)
 


### PR DESCRIPTION
See valid values at https://github.com/ensime/ensime-emacs/blob/f1ca2bd6de9b4e7eabe198ada75196183a1862c0/ensime-vars.el#L51
Alternatively, could be set to nil (to avoid slowdown for complex project by default).