### PR TITLE
Check if the hydra feature is enabled before opening smerge hydra

### DIFF
--- a/modules/feature/version-control/autoload.el
+++ b/modules/feature/version-control/autoload.el
@@ -45,7 +45,9 @@ repository root."
     (goto-char (point-min))
     (when (re-search-forward "^<<<<<<< " nil :noerror)
       (smerge-mode 1)
-      (when +vcs-auto-hydra-smerge (+hydra-smerge/body)))))
+      (when (and (featurep 'hydra)
+                 +vcs-auto-hydra-smerge)
+        (+hydra-smerge/body)))))
 
 ;;;###autoload
 (defun +vcs*update-header-line (&rest _)


### PR DESCRIPTION
Pretty self explanatory ... I was receiving void function errors when ```+hydra-smerge/body``` was being called when the hydra feature was not enabled.

On the plus side, this promped me to enable the hydra module which is pretty awesome! 👍 