### PR TITLE
Gracefully handle +ivy-tasks match errors

### DIFF
--- a/modules/completion/ivy/autoload/ivy.el
+++ b/modules/completion/ivy/autoload/ivy.el
@@ -110,11 +110,17 @@ If WORKSPACE-ONLY-P (universal arg), limit to buffers in the current workspace."
     (save-match-data
       (cl-loop with out = (shell-command-to-string cmd)
                for x in (and out (split-string out "\n" t))
-               when (string-match
-                     (concat "^\\([^:]+\\):\\([0-9]+\\):.+\\("
-                             (string-join task-tags "\\|")
-                             "\\):?\\s-*\\(.+\\)")
-                     x)
+               when (condition-case-unless-debug ex
+                      (string-match
+                       (concat "^\\([^:]+\\):\\([0-9]+\\):.+\\("
+                               (string-join task-tags "\\|")
+                               "\\):?\\s-*\\(.+\\)")
+                       x)
+                      (error
+                       (message! (red "Error matching task in file: (%s) %s"
+                                      (error-message-string ex)
+                                      (car (split-string x ":"))))
+                       nil))
                collect `((type . ,(match-string 3 x))
                          (desc . ,(match-string 4 x))
                          (file . ,(match-string 1 x))


### PR DESCRIPTION
## Problem
When trying to use +ivy-tasks in one of my projects it was failing w/ error:
`(Stack overflow in regexp matcher)`. This was due to ripgrep searching a folder
in the project root containing a minified bootstrap css source map file (which
had a `TODO:` in it). Since that file was a single line of text concatenated
together, the regex was getting passed ~540KB of text.

## Solution
To make it easier to recognize what is causing +ivy-tasks to fail I wrapped the
failing code in `condition-case-unless-debug` and report the error and the file
causing the error using `message!`. So now if there is a failure during the
extraction of a task from the search cmd's results, it returns non-failing results
and alerts the user in separate pop-up with information about why it failed.

Below is text and screenshot example of new failing behavior:
```
Error matching task in file: (Stack overflow in regexp matcher) /Users/brandon/dev/test-project/client/public/assets/bootstrap-3.3.6/css/bootstrap.css.map
Error matching task in file: (Stack overflow in regexp matcher) /Users/brandon/dev/test-project/client/public/assets/bootstrap-3.3.6/css/bootstrap.min.css.map
```
![image](https://user-images.githubusercontent.com/126236/29306610-46041f92-8153-11e7-9323-0b5fa327e296.png)

## Notes
 - To avoid including the bootstrap file in the ripgrep search result, I added a
`.ignore` file to the project that tells `rg` to ignore it.
 - I was surprised that this problem file was include in the ivy-tasks search
because I expected the search to respect projectile ignore settings. Respecting
projectile's ignored/unignored files and directories wouldn't be too difficult
considering projectile provides a robust collection of functions to help support
this. Also projectile's `projectile-ag` function is a great reference.